### PR TITLE
Updating dep github.com/gholt/store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,3 @@ install:
 
 up:
 	glide up -u
-
-# Example of updating a single dependency (and its dependencies):
-#   glide get -s -u -v github.com/gholt/store

--- a/vendor/github.com/gholt/store/compaction.got
+++ b/vendor/github.com/gholt/store/compaction.got
@@ -186,7 +186,7 @@ func (store *default{{.T}}Store) compactionWorker(jobChan chan *{{.t}}Compaction
             continue
         }
         // TODO: This 1000 should be in the Config.
-        // If total is less than 100, it'll automatically get compacted.
+        // If total is less than 1000, it'll automatically get compacted.
         if total < 1000 {
             atomic.AddInt32(&store.smallFileCompactions, 1)
         } else {
@@ -319,8 +319,22 @@ func (store *default{{.T}}Store) compactFile(nametoc string, blockID uint32, con
                         atomic.AddUint32(&stale, 1)
                         continue
                     }
+                    // Must assume entry was deleted and the tombstone has
+                    // expired; must not resurrect and if there had been a read
+                    // error on initial startup but now compaction can read the
+                    // value, it's better to just let replication from another
+                    // node take place anyway.
+                    if timestampBits == 0 { // not found
+                        atomic.AddUint32(&stale, 1)
+                        continue
+                    }
                     timestampBits, value, err := store.read(wr.KeyA, wr.KeyB{{if eq .t "group"}}, wr.ChildKeyA, wr.ChildKeyB{{end}}, value[:0])
-                    if err != nil && !IsNotFound(err) {
+                    // Same as above note about timestampBits == 0.
+                    if IsNotFound(err) {
+                        atomic.AddUint32(&stale, 1)
+                        continue
+                    }
+                    if err != nil {
                         store.logError("compactFile: error reading while compacting %s: %s", nametoc, err)
                         atomic.AddUint32(&readErrorCount, 1)
                         // Keeps going, but the readErrorCount will let it know

--- a/vendor/github.com/gholt/store/config.got
+++ b/vendor/github.com/gholt/store/config.got
@@ -220,7 +220,7 @@ type {{.T}}StoreConfig struct {
     // the Path or TOCPath device grows above this threshold, writes will be
     // automatically disabled.
     // 0 will use the default; a negative value will disable the check.
-    // default: 0.95 (95%)
+    // default: 0.94 (94%)
     DiskUsageDisableThreshold float32
     // DiskUsageReenableThreshold controls when to automatically re-enable
     // writes; the number is a percentage (1 == 100%). If writes are
@@ -266,7 +266,7 @@ type {{.T}}StoreConfig struct {
     // the number is a percentage (1 == 100%). If the percentage of used memory
     // grows above this threshold, writes will be automatically disabled.
     // 0 will use the default; a negative value will disable the check.
-    // default: 0.95 (95%)
+    // default: 0.94 (94%)
     MemUsageDisableThreshold float32
     // MemUsageReenableThreshold controls when to automatically re-enable
     // writes; the number is a percentage (1 == 100%). If writes are
@@ -803,7 +803,7 @@ func resolve{{.T}}StoreConfig(c *{{.T}}StoreConfig) *{{.T}}StoreConfig {
         }
     }
     if cfg.DiskUsageDisableThreshold == 0 {
-        cfg.DiskUsageDisableThreshold = 0.95
+        cfg.DiskUsageDisableThreshold = 0.94
     }
     if cfg.DiskUsageDisableThreshold < 0 {
         cfg.DiskUsageDisableThreshold = 0
@@ -876,7 +876,7 @@ func resolve{{.T}}StoreConfig(c *{{.T}}StoreConfig) *{{.T}}StoreConfig {
         }
     }
     if cfg.MemUsageDisableThreshold == 0 {
-        cfg.MemUsageDisableThreshold = 0.95
+        cfg.MemUsageDisableThreshold = 0.94
     }
     if cfg.MemUsageDisableThreshold < 0 {
         cfg.MemUsageDisableThreshold = 0

--- a/vendor/github.com/gholt/store/groupcompaction_GEN_.go
+++ b/vendor/github.com/gholt/store/groupcompaction_GEN_.go
@@ -186,7 +186,7 @@ func (store *defaultGroupStore) compactionWorker(jobChan chan *groupCompactionJo
 			continue
 		}
 		// TODO: This 1000 should be in the Config.
-		// If total is less than 100, it'll automatically get compacted.
+		// If total is less than 1000, it'll automatically get compacted.
 		if total < 1000 {
 			atomic.AddInt32(&store.smallFileCompactions, 1)
 		} else {
@@ -319,8 +319,22 @@ func (store *defaultGroupStore) compactFile(nametoc string, blockID uint32, cont
 						atomic.AddUint32(&stale, 1)
 						continue
 					}
+					// Must assume entry was deleted and the tombstone has
+					// expired; must not resurrect and if there had been a read
+					// error on initial startup but now compaction can read the
+					// value, it's better to just let replication from another
+					// node take place anyway.
+					if timestampBits == 0 { // not found
+						atomic.AddUint32(&stale, 1)
+						continue
+					}
 					timestampBits, value, err := store.read(wr.KeyA, wr.KeyB, wr.ChildKeyA, wr.ChildKeyB, value[:0])
-					if err != nil && !IsNotFound(err) {
+					// Same as above note about timestampBits == 0.
+					if IsNotFound(err) {
+						atomic.AddUint32(&stale, 1)
+						continue
+					}
+					if err != nil {
 						store.logError("compactFile: error reading while compacting %s: %s", nametoc, err)
 						atomic.AddUint32(&readErrorCount, 1)
 						// Keeps going, but the readErrorCount will let it know

--- a/vendor/github.com/gholt/store/groupconfig_GEN_.go
+++ b/vendor/github.com/gholt/store/groupconfig_GEN_.go
@@ -220,7 +220,7 @@ type GroupStoreConfig struct {
 	// the Path or TOCPath device grows above this threshold, writes will be
 	// automatically disabled.
 	// 0 will use the default; a negative value will disable the check.
-	// default: 0.95 (95%)
+	// default: 0.94 (94%)
 	DiskUsageDisableThreshold float32
 	// DiskUsageReenableThreshold controls when to automatically re-enable
 	// writes; the number is a percentage (1 == 100%). If writes are
@@ -266,7 +266,7 @@ type GroupStoreConfig struct {
 	// the number is a percentage (1 == 100%). If the percentage of used memory
 	// grows above this threshold, writes will be automatically disabled.
 	// 0 will use the default; a negative value will disable the check.
-	// default: 0.95 (95%)
+	// default: 0.94 (94%)
 	MemUsageDisableThreshold float32
 	// MemUsageReenableThreshold controls when to automatically re-enable
 	// writes; the number is a percentage (1 == 100%). If writes are
@@ -803,7 +803,7 @@ func resolveGroupStoreConfig(c *GroupStoreConfig) *GroupStoreConfig {
 		}
 	}
 	if cfg.DiskUsageDisableThreshold == 0 {
-		cfg.DiskUsageDisableThreshold = 0.95
+		cfg.DiskUsageDisableThreshold = 0.94
 	}
 	if cfg.DiskUsageDisableThreshold < 0 {
 		cfg.DiskUsageDisableThreshold = 0
@@ -876,7 +876,7 @@ func resolveGroupStoreConfig(c *GroupStoreConfig) *GroupStoreConfig {
 		}
 	}
 	if cfg.MemUsageDisableThreshold == 0 {
-		cfg.MemUsageDisableThreshold = 0.95
+		cfg.MemUsageDisableThreshold = 0.94
 	}
 	if cfg.MemUsageDisableThreshold < 0 {
 		cfg.MemUsageDisableThreshold = 0

--- a/vendor/github.com/gholt/store/valueconfig_GEN_.go
+++ b/vendor/github.com/gholt/store/valueconfig_GEN_.go
@@ -220,7 +220,7 @@ type ValueStoreConfig struct {
 	// the Path or TOCPath device grows above this threshold, writes will be
 	// automatically disabled.
 	// 0 will use the default; a negative value will disable the check.
-	// default: 0.95 (95%)
+	// default: 0.94 (94%)
 	DiskUsageDisableThreshold float32
 	// DiskUsageReenableThreshold controls when to automatically re-enable
 	// writes; the number is a percentage (1 == 100%). If writes are
@@ -266,7 +266,7 @@ type ValueStoreConfig struct {
 	// the number is a percentage (1 == 100%). If the percentage of used memory
 	// grows above this threshold, writes will be automatically disabled.
 	// 0 will use the default; a negative value will disable the check.
-	// default: 0.95 (95%)
+	// default: 0.94 (94%)
 	MemUsageDisableThreshold float32
 	// MemUsageReenableThreshold controls when to automatically re-enable
 	// writes; the number is a percentage (1 == 100%). If writes are
@@ -803,7 +803,7 @@ func resolveValueStoreConfig(c *ValueStoreConfig) *ValueStoreConfig {
 		}
 	}
 	if cfg.DiskUsageDisableThreshold == 0 {
-		cfg.DiskUsageDisableThreshold = 0.95
+		cfg.DiskUsageDisableThreshold = 0.94
 	}
 	if cfg.DiskUsageDisableThreshold < 0 {
 		cfg.DiskUsageDisableThreshold = 0
@@ -876,7 +876,7 @@ func resolveValueStoreConfig(c *ValueStoreConfig) *ValueStoreConfig {
 		}
 	}
 	if cfg.MemUsageDisableThreshold == 0 {
-		cfg.MemUsageDisableThreshold = 0.95
+		cfg.MemUsageDisableThreshold = 0.94
 	}
 	if cfg.MemUsageDisableThreshold < 0 {
 		cfg.MemUsageDisableThreshold = 0


### PR DESCRIPTION
Bug fix for compaction resurrection

Bring the usage disable threshold down to 94%

Linux file systems report 100% full at 95% full with the default 5%
reserve-for-root-only. Setting our usage disable default to 94% will
"look better" on these systems as at our cutoff, tools like df will show
99% full instead of 100%. 100% could have caused misunderstandings and
thinking that the store cutoff did not work.
