### PR TITLE
Enabledelete

### DIFF
--- a/formic/formicd/fs_api.go
+++ b/formic/formicd/fs_api.go
@@ -438,9 +438,9 @@ func (s *FileSystemAPIServer) DeleteFS(ctx context.Context, r *pb.DeleteFSReques
 
 	// Test if file system is empty.
 	keyA, keyB := murmur3.Sum128(id)
-	items, err := s.gstore.ReadGroup(context.Background(), pKeyA, pKeyB)
+	items, err := s.gstore.ReadGroup(context.Background(), keyA, keyB)
 	if len(items) != 0 {
-		log.Info("DELETE FAILED", zap.String("error", "FileSystemNotEmpty"), zap.String("fsid", r.FSid))
+		log.Info("DELETE FAILED", zap.String("error", "FileSystemNotEmpty"), zap.String("ItemCount", string(len(items))))
 		return nil, errf(codes.FailedPrecondition, "%v", "File System Not Empty")
 	}
 

--- a/formic/formicd/fs_api.go
+++ b/formic/formicd/fs_api.go
@@ -450,7 +450,7 @@ func (s *FileSystemAPIServer) DeleteFS(ctx context.Context, r *pb.DeleteFSReques
 	_, err = s.vstore.Delete(context.Background(), keyA, keyB, timestampMicro)
 	if err != nil {
 		if !store.IsNotFound(err) {
-			log.Error("DELETE FAILED", zap.String("type", "RootRecord"), zap.String("fsid", r.FSid), zap.Error(err))
+			log.Error("DELETE FAILED", zap.String("type", "RootRecord"))
 			return nil, errf(codes.Internal, "%v", err)
 		}
 	}
@@ -475,19 +475,19 @@ func (s *FileSystemAPIServer) DeleteFS(ctx context.Context, r *pb.DeleteFSReques
 		for _, v := range items {
 			err = json.Unmarshal(v.Value, &addrData)
 			if err != nil {
-				log.Error("DELETE FAILED", zap.String("type", "UnMarshal"), zap.String("fsid", r.FSid), zap.Error(err))
+				log.Error("DELETE FAILED", zap.String("type", "UnMarshal"), zap.Error(err))
 				return nil, errf(codes.Internal, "%v", err)
 			}
 			err = s.deleteEntry(pKey, addrData.Addr)
 			if err != nil {
-				log.Error("DELETE FAILED", zap.String("type", "IPDelete"), zap.String("fsid", r.FSid), zap.Error(err))
+				log.Error("DELETE FAILED", zap.String("type", "IPDelete"), zap.Error(err))
 				return nil, errf(codes.Internal, "%v", err)
 			}
 			rowcount++
 		}
 	}
 	if err != nil {
-		log.Error("DELETE FAILED", zap.String("type", "ReadIPGroup"), zap.String("fsid", r.FSid), zap.Error(err))
+		log.Error("DELETE FAILED", zap.String("type", "ReadIPGroup"), zap.Error(err))
 		return nil, errf(codes.Internal, "%v", err)
 	}
 	// Delete File System Attributes
@@ -495,7 +495,7 @@ func (s *FileSystemAPIServer) DeleteFS(ctx context.Context, r *pb.DeleteFSReques
 	pKey = fmt.Sprintf("/fs/%s", r.FSid)
 	err = s.deleteEntry(pKey, "name")
 	if err != nil {
-		log.Error("DELETE FAILED", zap.String("type", "FSAttributeName"), zap.String("fsid", r.FSid), zap.Error(err))
+		log.Error("DELETE FAILED", zap.String("type", "FSAttributeName"), zap.Error(err))
 		return nil, errf(codes.Internal, "%v", err)
 	}
 	rowcount++
@@ -504,7 +504,7 @@ func (s *FileSystemAPIServer) DeleteFS(ctx context.Context, r *pb.DeleteFSReques
 	pKey = fmt.Sprintf("/acct/%s", acctID)
 	err = s.deleteEntry(pKey, r.FSid)
 	if err != nil {
-		log.Error("DELETE FAILED", zap.String("type", "FSAttributeName"), zap.String("fsid", r.FSid), zap.Error(err))
+		log.Error("DELETE FAILED", zap.String("type", "FSAttributeName"), zap.Error(err))
 		return nil, errf(codes.Internal, "%v", err)
 	}
 	rowcount++
@@ -512,14 +512,14 @@ func (s *FileSystemAPIServer) DeleteFS(ctx context.Context, r *pb.DeleteFSReques
 	//    /fs 								FSID						FileSysRef
 	err = s.deleteEntry("/fs", r.FSid)
 	if err != nil {
-		log.Error("DELETE FAILED", zap.String("type", "FSAttributeName"), zap.String("fsid", r.FSid), zap.Error(err))
+		log.Error("DELETE FAILED", zap.String("type", "FSAttributeName"), zap.Error(err))
 		return nil, errf(codes.Internal, "%v", err)
 	}
 	rowcount++
 
 	// Prep things to return
 	// Log Operation
-	log.Info("DELETE", zap.String("acct", acctID), zap.String("fsid", r.FSid), zap.String("items", string(rowcount)))
+	log.Info("DELETE", zap.String("ItemsDeleted", fmt.Sprintf("%d", rowcount)))
 	return &pb.DeleteFSResponse{Data: r.FSid}, nil
 }
 

--- a/formic/formicd/fs_api.go
+++ b/formic/formicd/fs_api.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/creiht/formic"
 	pb "github.com/getcfs/megacfs/formic/proto"
 	"github.com/gholt/brimtime"
 	"github.com/gholt/store"
@@ -87,6 +88,7 @@ func clear(v interface{}) {
 // FileSystemAPIServer is used to implement oohhc
 type FileSystemAPIServer struct {
 	gstore store.GroupStore
+	vstore store.ValueStore
 	log    zap.Logger
 }
 
@@ -94,9 +96,10 @@ type FileSystemAPIServer struct {
 var FSAttrList = []string{"name"}
 
 // NewFileSystemAPIServer ...
-func NewFileSystemAPIServer(store store.GroupStore, logger zap.Logger) *FileSystemAPIServer {
+func NewFileSystemAPIServer(grpstore store.GroupStore, valstore store.ValueStore, logger zap.Logger) *FileSystemAPIServer {
 	s := &FileSystemAPIServer{
-		gstore: store,
+		gstore: grpstore,
+		vstore: valstore,
 		log:    logger,
 	}
 
@@ -388,7 +391,11 @@ func (s *FileSystemAPIServer) ListFS(ctx context.Context, r *pb.ListFSRequest) (
 // DeleteFS ...
 func (s *FileSystemAPIServer) DeleteFS(ctx context.Context, r *pb.DeleteFSRequest) (*pb.DeleteFSResponse, error) {
 	var err error
+	var value []byte
+	var fsRef FileSysRef
+	var addrData AddrRef
 	srcAddr := ""
+	rowcount := 0
 	// Get incomming ip
 	pr, ok := peer.FromContext(ctx)
 	if ok {
@@ -404,11 +411,113 @@ func (s *FileSystemAPIServer) DeleteFS(ctx context.Context, r *pb.DeleteFSReques
 	log := s.log.With(zap.String("src", srcAddr), zap.String("acct", acctID), zap.String("fsid", r.FSid))
 
 	// Validate Token/Account own this file system
+	pKey := fmt.Sprintf("/fs")
+	pKeyA, pKeyB := murmur3.Sum128([]byte(pKey))
+	cKeyA, cKeyB := murmur3.Sum128([]byte(r.FSid))
+	_, value, err = s.gstore.Read(context.Background(), pKeyA, pKeyB, cKeyA, cKeyB, nil)
+	if store.IsNotFound(err) {
+		log.Info("DELETE FAILED", zap.String("error", "IDNotFound"))
+		return nil, errf(codes.NotFound, "%v", "File System ID Not Found")
+	}
+	if err != nil {
+		log.Error("DELETE FAILED", zap.Error(err))
+		return nil, errf(codes.Internal, "%v", err)
+	}
+	err = json.Unmarshal(value, &fsRef)
+	if err != nil {
+		log.Error("DELETE FAILED", zap.Error(err))
+		return nil, errf(codes.Internal, "%v", err)
+	}
+	if fsRef.AcctID != acctID {
+		log.Info("DELETE FAILED", zap.String("error", "AccountMismatch"), zap.String("acct", fsRef.AcctID))
+		return nil, errf(codes.FailedPrecondition, "%v", "Account Mismatch")
+	}
+
+	// Test if file system is empty.
+	id := formic.GetID([]byte(r.FSid), 1, 0)
+	keyA, keyB := murmur3.Sum128(id)
+	// n, _ := o.GetChunk(ctx, id)
+	timestampMicro := brimtime.TimeToUnixMicro(time.Now())
+	n, _ := s.vstore.Read(context.Background(), keyA, keyB, timestampMicro)
+	if len(n) != 0 {
+		log.Info("DELETE FAILED", zap.String("error", "FileSystemNotEmpty"), zap.String("fsid", r.FSid))
+		return nil, errf(codes.FailedPrecondition, "%v", "File System Not Empty")
+	}
+
+	// Remove the root file system entry from the value store
+	timestampMicro = brimtime.TimeToUnixMicro(time.Now())
+	_, err = s.vstore.Delete(context.Background(), keyA, keyB, timestampMicro)
+	if err != nil {
+		log.Error("DELETE FAILED", zap.String("type", "RootRecord"), zap.String("fsid", r.FSid), zap.Error(err))
+		return nil, errf(codes.Internal, "%v", err)
+	}
+
+	// Delete this record set
+	// IP Addresses																				(x records)
+	//    /fs/FSID/addr			  addr						AddrRef
+	// File System Attributes															(1 record)
+	//    /fs/FSID						name						FileSysAttr
+	// File System Account Reference											(1 record)
+	//    /acct/acctID				FSID						FileSysRef
+	// File System Reference 															(1 record)
+	//    /fs 								FSID						FileSysRef
+
+	// Read list of granted ip addresses
+	// group-lookup printf("/fs/%s/addr", FSID)
+	pKey = fmt.Sprintf("/fs/%s/addr", r.FSid)
+	pKeyA, pKeyB = murmur3.Sum128([]byte(pKey))
+	items, err := s.gstore.ReadGroup(context.Background(), pKeyA, pKeyB)
+	if !store.IsNotFound(err) {
+		// No addr granted
+		for _, v := range items {
+			err = json.Unmarshal(v.Value, &addrData)
+			if err != nil {
+				log.Error("DELETE FAILED", zap.String("type", "UnMarshal"), zap.String("fsid", r.FSid), zap.Error(err))
+				return nil, errf(codes.Internal, "%v", err)
+			}
+			err = s.deleteEntry(pKey, addrData.Addr)
+			if err != nil {
+				log.Error("DELETE FAILED", zap.String("type", "IPDelete"), zap.String("fsid", r.FSid), zap.Error(err))
+				return nil, errf(codes.Internal, "%v", err)
+			}
+			rowcount++
+		}
+	}
+	if err != nil {
+		log.Error("DELETE FAILED", zap.String("type", "ReadIPGroup"), zap.String("fsid", r.FSid), zap.Error(err))
+		return nil, errf(codes.Internal, "%v", err)
+	}
+	// Delete File System Attributes
+	//    /fs/FSID						name						FileSysAttr
+	pKey = fmt.Sprintf("/fs/%s", r.FSid)
+	err = s.deleteEntry(pKey, "name")
+	if err != nil {
+		log.Error("DELETE FAILED", zap.String("type", "FSAttributeName"), zap.String("fsid", r.FSid), zap.Error(err))
+		return nil, errf(codes.Internal, "%v", err)
+	}
+	rowcount++
+	// Delete File System Account Reference
+	//    /acct/acctID				FSID						FileSysRef
+	pKey = fmt.Sprintf("/acct/%s", acctID)
+	err = s.deleteEntry(pKey, r.FSid)
+	if err != nil {
+		log.Error("DELETE FAILED", zap.String("type", "FSAttributeName"), zap.String("fsid", r.FSid), zap.Error(err))
+		return nil, errf(codes.Internal, "%v", err)
+	}
+	rowcount++
+	// File System Reference
+	//    /fs 								FSID						FileSysRef
+	err = s.deleteEntry("/fs", r.FSid)
+	if err != nil {
+		log.Error("DELETE FAILED", zap.String("type", "FSAttributeName"), zap.String("fsid", r.FSid), zap.Error(err))
+		return nil, errf(codes.Internal, "%v", err)
+	}
+	rowcount++
 
 	// Prep things to return
 	// Log Operation
-	log.Info("DELETE NOTIMPLEMENTED")
-	return &pb.DeleteFSResponse{Data: "Delete Operation not supported at this time"}, nil
+	log.Info("DELETE", zap.String("acct", acctID), zap.String("fsid", r.FSid), zap.String("items", string(rowcount)))
+	return &pb.DeleteFSResponse{Data: r.FSid}, nil
 }
 
 // UpdateFS ...
@@ -614,6 +723,10 @@ func (s *FileSystemAPIServer) RevokeAddrFS(ctx context.Context, r *pb.RevokeAddr
 		log.Info("REVOKE FAILED", zap.String("error", "IDNotFound"))
 		return nil, errf(codes.NotFound, "%v", "File System ID Not Found")
 	}
+	if err != nil {
+		log.Error("REVOKE FAILED", zap.Error(err))
+		return nil, errf(codes.Internal, "%v", err)
+	}
 
 	// return Addr was revoked
 	// Log Operation
@@ -657,4 +770,18 @@ func (s *FileSystemAPIServer) validateToken(token string) (string, error) {
 	tenant := validateResp.Access.Token.Tenant.ID
 
 	return tenant, nil
+}
+
+// deleteEntry Deletes and entry in the group store and doesn't care if
+// its not Found
+func (s *FileSystemAPIServer) deleteEntry(pKey string, cKey string) error {
+	timestampMicro := brimtime.TimeToUnixMicro(time.Now())
+	pKeyA, pKeyB := murmur3.Sum128([]byte(pKey))
+	cKeyA, cKeyB := murmur3.Sum128([]byte(cKey))
+	_, err := s.gstore.Delete(context.Background(), pKeyA, pKeyB, cKeyA, cKeyB, timestampMicro)
+	if store.IsNotFound(err) || err == nil {
+		return nil
+	} else {
+		return err
+	}
 }

--- a/formic/formicd/fs_api.go
+++ b/formic/formicd/fs_api.go
@@ -433,8 +433,10 @@ func (s *FileSystemAPIServer) DeleteFS(ctx context.Context, r *pb.DeleteFSReques
 		return nil, errf(codes.FailedPrecondition, "%v", "Account Mismatch")
 	}
 
+	uuID, err := uuid.FromString(r.FSid)
+	id := formic.GetID(uuID.Bytes(), 1, 0)
+
 	// Test if file system is empty.
-	id := formic.GetID([]byte(r.FSid), 1, 0)
 	keyA, keyB := murmur3.Sum128(id)
 	items, err := s.gstore.ReadGroup(context.Background(), pKeyA, pKeyB)
 	if len(items) != 0 {
@@ -443,7 +445,6 @@ func (s *FileSystemAPIServer) DeleteFS(ctx context.Context, r *pb.DeleteFSReques
 	}
 
 	// Remove the root file system entry from the value store
-	id = formic.GetID([]byte(r.FSid), 1, 0)
 	keyA, keyB = murmur3.Sum128(id)
 	timestampMicro := brimtime.TimeToUnixMicro(time.Now())
 	_, err = s.vstore.Delete(context.Background(), keyA, keyB, timestampMicro)

--- a/formic/formicd/fs_api.go
+++ b/formic/formicd/fs_api.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/creiht/formic"
+	"github.com/getcfs/megacfs/formic"
 	pb "github.com/getcfs/megacfs/formic/proto"
 	"github.com/gholt/brimtime"
 	"github.com/gholt/store"

--- a/formic/formicd/main.go
+++ b/formic/formicd/main.go
@@ -177,7 +177,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to bind formicd to port", zap.Error(err))
 	}
-	pb.RegisterFileSystemAPIServer(s, NewFileSystemAPIServer(gstore, baseLogger.With(zap.String("name", "formicd.fs"))))
+	pb.RegisterFileSystemAPIServer(s, NewFileSystemAPIServer(gstore, vstore, baseLogger.With(zap.String("name", "formicd.fs"))))
 	pb.RegisterApiServer(s, NewApiServer(fs, cfg.nodeId, comms, logger))
 	logger.Info("Starting formic and the filesystem API", zap.Int("port", cfg.port))
 	s.Serve(l)


### PR DESCRIPTION
Add the ability to delete a file system's control data.   A filesystem must be empty for the delete to be successful. 
