### PR TITLE
Change grant to revoke in the case statement

### DIFF
--- a/formic/cfs/main.go
+++ b/formic/cfs/main.go
@@ -379,7 +379,7 @@ func main() {
 			fmt.Println("You must run \"cfs configure\" first.")
 			os.Exit(1)
 		}
-		err := grant(region, username, apikey)
+		err := revoke(region, username, apikey)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)


### PR DESCRIPTION
Fixed typo in client.  Changed "grant" to "revoke" in the case statement.
