### PR TITLE
Enhancegrant

### DIFF
--- a/formic/cfs/client.go
+++ b/formic/cfs/client.go
@@ -225,20 +225,27 @@ func update(region, username, apikey string) error {
 }
 
 func grant(region, username, apikey string) error {
+	var ip, fsid string
 	f := flag.NewFlagSet("grant", flag.ContinueOnError)
 	f.Usage = func() {
 		fmt.Println("Usage:")
-		fmt.Println("    cfs grant <ip> <fsid>")
+		fmt.Println("    cfs grant [ip] <fsid>")
 		fmt.Println("Example:")
+		fmt.Println("    cfs grant 11111111-1111-1111-1111-111111111111")
 		fmt.Println("    cfs grant 1.1.1.1 11111111-1111-1111-1111-111111111111")
 		os.Exit(1)
 	}
 	f.Parse(flag.Args()[1:])
-	if f.NArg() != 2 {
+	if f.NArg() == 1 {
+		ip = ""
+		fsid = f.Args()[0]
+	} else if f.NArg() == 2 {
+		ip = f.Args()[0]
+		fsid = f.Args()[1]
+	} else {
+
 		f.Usage()
 	}
-	ip := f.Args()[0]
-	fsid := f.Args()[1]
 	addr, ok := regions[region]
 	if !ok {
 		return errors.New(fmt.Sprintf("Invalid region: %s\n", region))
@@ -256,20 +263,26 @@ func grant(region, username, apikey string) error {
 }
 
 func revoke(region, username, apikey string) error {
+	var ip, fsid string
 	f := flag.NewFlagSet("revoke", flag.ContinueOnError)
 	f.Usage = func() {
 		fmt.Println("Usage:")
-		fmt.Println("    cfs revoke <ip> <fsid>")
+		fmt.Println("    cfs revoke [ip] <fsid>")
 		fmt.Println("Example:")
+		fmt.Println("    cfs revoke 11111111-1111-1111-1111-111111111111")
 		fmt.Println("    cfs revoke 1.1.1.1 11111111-1111-1111-1111-111111111111")
 		os.Exit(1)
 	}
 	f.Parse(flag.Args()[1:])
-	if f.NArg() != 2 {
+	if f.NArg() == 1 {
+		ip = ""
+		fsid = f.Args()[0]
+	} else if f.NArg() == 2 {
+		ip = f.Args()[0]
+		fsid = f.Args()[1]
+	} else {
 		f.Usage()
 	}
-	ip := f.Args()[0]
-	fsid := f.Args()[1]
 	addr, ok := regions[region]
 	if !ok {
 		return errors.New(fmt.Sprintf("Invalid region: %s\n", region))

--- a/formic/cfs/client.go
+++ b/formic/cfs/client.go
@@ -254,11 +254,11 @@ func grant(region, username, apikey string) error {
 	defer c.Close()
 	ws := pb.NewFileSystemAPIClient(c)
 	token := auth(username, apikey)
-	_, err := ws.GrantAddrFS(context.Background(), &pb.GrantAddrFSRequest{Token: token, FSid: fsid, Addr: ip})
+	res, err := ws.GrantAddrFS(context.Background(), &pb.GrantAddrFSRequest{Token: token, FSid: fsid, Addr: ip})
 	if err != nil {
 		return errors.New(fmt.Sprintf("Request Error: %v\n", err))
 	}
-
+	fmt.Println(res.Data)
 	return nil
 }
 
@@ -291,10 +291,10 @@ func revoke(region, username, apikey string) error {
 	defer c.Close()
 	ws := pb.NewFileSystemAPIClient(c)
 	token := auth(username, apikey)
-	_, err := ws.RevokeAddrFS(context.Background(), &pb.RevokeAddrFSRequest{Token: token, FSid: fsid, Addr: ip})
+	res, err := ws.RevokeAddrFS(context.Background(), &pb.RevokeAddrFSRequest{Token: token, FSid: fsid, Addr: ip})
 	if err != nil {
 		return errors.New(fmt.Sprintf("Request Error: %v\n", err))
 	}
-
+	fmt.Println(res.Data)
 	return nil
 }

--- a/formic/formicd/fs_api.go
+++ b/formic/formicd/fs_api.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/getcfs/megacfs/formic"
@@ -673,6 +674,7 @@ func (s *FileSystemAPIServer) GrantAddrFS(ctx context.Context, r *pb.GrantAddrFS
 	var addrData AddrRef
 	var addrByte []byte
 	srcAddr := ""
+	srcAddrIP := ""
 
 	// Get incomming ip
 	pr, ok := peer.FromContext(ctx)
@@ -712,9 +714,14 @@ func (s *FileSystemAPIServer) GrantAddrFS(ctx context.Context, r *pb.GrantAddrFS
 
 	// GRANT an file system entry for the addr
 	// 		write /fs/FSID/addr			addr						AddrRef
+	if r.Addr == "" {
+		srcAddrIP = strings.Split(srcAddr, ":")[0]
+	} else {
+		srcAddrIP = r.Addr
+	}
 	pKey = fmt.Sprintf("/fs/%s/addr", r.FSid)
 	pKeyA, pKeyB = murmur3.Sum128([]byte(pKey))
-	cKeyA, cKeyB = murmur3.Sum128([]byte(r.Addr))
+	cKeyA, cKeyB = murmur3.Sum128([]byte(srcAddrIP))
 	timestampMicro := brimtime.TimeToUnixMicro(time.Now())
 	addrData.Addr = r.Addr
 	addrData.FSID = r.FSid
@@ -742,6 +749,7 @@ func (s *FileSystemAPIServer) RevokeAddrFS(ctx context.Context, r *pb.RevokeAddr
 	var value []byte
 	var fsRef FileSysRef
 	srcAddr := ""
+	srcAddrIP := ""
 
 	// Get incomming ip
 	pr, ok := peer.FromContext(ctx)
@@ -781,9 +789,14 @@ func (s *FileSystemAPIServer) RevokeAddrFS(ctx context.Context, r *pb.RevokeAddr
 
 	// REVOKE an file system entry for the addr
 	// 		delete /fs/FSID/addr			addr						AddrRef
+	if r.Addr == "" {
+		srcAddrIP = strings.Split(srcAddr, ":")[0]
+	} else {
+		srcAddrIP = r.Addr
+	}
 	pKey = fmt.Sprintf("/fs/%s/addr", r.FSid)
 	pKeyA, pKeyB = murmur3.Sum128([]byte(pKey))
-	cKeyA, cKeyB = murmur3.Sum128([]byte(r.Addr))
+	cKeyA, cKeyB = murmur3.Sum128([]byte(srcAddrIP))
 	timestampMicro := brimtime.TimeToUnixMicro(time.Now())
 	_, err = s.gstore.Delete(context.Background(), pKeyA, pKeyB, cKeyA, cKeyB, timestampMicro)
 	if store.IsNotFound(err) {

--- a/formic/formicd/fs_api.go
+++ b/formic/formicd/fs_api.go
@@ -723,7 +723,7 @@ func (s *FileSystemAPIServer) GrantAddrFS(ctx context.Context, r *pb.GrantAddrFS
 	pKeyA, pKeyB = murmur3.Sum128([]byte(pKey))
 	cKeyA, cKeyB = murmur3.Sum128([]byte(srcAddrIP))
 	timestampMicro := brimtime.TimeToUnixMicro(time.Now())
-	addrData.Addr = r.Addr
+	addrData.Addr = srcAddrIP
 	addrData.FSID = r.FSid
 	addrByte, err = json.Marshal(addrData)
 	if err != nil {

--- a/formic/formicd/fs_api.go
+++ b/formic/formicd/fs_api.go
@@ -738,8 +738,8 @@ func (s *FileSystemAPIServer) GrantAddrFS(ctx context.Context, r *pb.GrantAddrFS
 
 	// return Addr was Granted
 	// Log Operation
-	log.Info("GRANT", zap.String("addr", r.Addr))
-	return &pb.GrantAddrFSResponse{Data: r.FSid}, nil
+	log.Info("GRANT", zap.String("addr", srcAddrIP))
+	return &pb.GrantAddrFSResponse{Data: srcAddrIP}, nil
 }
 
 // RevokeAddrFS ...
@@ -810,8 +810,8 @@ func (s *FileSystemAPIServer) RevokeAddrFS(ctx context.Context, r *pb.RevokeAddr
 
 	// return Addr was revoked
 	// Log Operation
-	log.Info("REVOKE", zap.String("addr", r.Addr))
-	return &pb.RevokeAddrFSResponse{Data: r.FSid}, nil
+	log.Info("REVOKE", zap.String("addr", srcAddrIP))
+	return &pb.RevokeAddrFSResponse{Data: srcAddrIP}, nil
 }
 
 // ValidateResponse ...


### PR DESCRIPTION
This changes the behavior of both the grant and revoke command to use the IP referenced in the server connection and not a required command line field.  This change will make the IP command line parameter optional.
