### PR TITLE
Cleaned up node id generation

### DIFF
--- a/formic/api.go
+++ b/formic/api.go
@@ -38,19 +38,18 @@ type apiServer struct {
 }
 
 // NewApiServer ...
-func NewApiServer(fs FileService, nodeID int, comms *StoreComms, logger zap.Logger) *apiServer {
+func NewApiServer(fs FileService, nodeID int, comms *StoreComms, logger zap.Logger) (uint64, *apiServer) {
 	s := new(apiServer)
 	s.fs = fs
 	s.comms = comms
 	s.validIPs = make(map[string]map[string]time.Time)
-	logger.Debug("NodeID", zap.Int("nodeID", nodeID))
 	s.fl = flother.NewFlother(time.Time{}, uint64(nodeID))
 	s.blocksize = int64(1024 * 64) // Default Block Size (64K)
 	s.updateChan = make(chan *UpdateItem, 1000)
 	s.log = logger
 	updates := newUpdatinator(s.updateChan, fs)
 	go updates.Run()
-	return s
+	return s.fl.GetNodeID(), s
 }
 
 // GenerateBlockID ...

--- a/formic/flother/flother.go
+++ b/formic/flother/flother.go
@@ -5,6 +5,7 @@
 package flother
 
 import (
+	"math"
 	"sync/atomic"
 	"time"
 )
@@ -28,6 +29,8 @@ func NewFlother(epoch time.Time, node uint64) *Flother {
 		counter:  0,
 		node:     node,
 	}
+	// ensure that node is only the number of bits we want
+	f.node = node & uint64(math.Pow(2, float64(f.nodeBits))-1)
 	return f
 }
 
@@ -39,4 +42,9 @@ func (f *Flother) GetID() uint64 {
 	c := atomic.AddUint64(&f.counter, 1)
 	id |= c % (1 << f.seqBits)
 	return id
+}
+
+// Get the node ID
+func (f *Flother) GetNodeID() uint64 {
+	return f.node
 }

--- a/formic/formic.go
+++ b/formic/formic.go
@@ -136,10 +136,11 @@ func NewFormicServer(cfg *Config, logger zap.Logger) error {
 	// TODO: Get a better way to get the Node ID
 	formicNodeID := cfg.NodeID
 	if formicNodeID == -1 {
-		formicNodeID = int(murmur3.Sum64([]byte(cfg.IpAddr)))
+		formicNodeID = int(murmur3.Sum32([]byte(cfg.IpAddr)))
 	}
-	pb.RegisterApiServer(s, NewApiServer(fs, formicNodeID, comms, logger))
-	logger.Info("Starting formic and the filesystem API", zap.Int("addr", formicNodeID))
+	nodeID, apiServer := NewApiServer(fs, formicNodeID, comms, logger)
+	pb.RegisterApiServer(s, apiServer)
+	logger.Info("Starting formic and the filesystem API", zap.Uint64("node", nodeID))
 	go s.Serve(l)
 	return nil
 }


### PR DESCRIPTION
1.  Flother now truncates the nodeid to the bits it is going to use
2.  The truncated nodeid is now reported on startup for easier debugging
3.  Changed to Sum32 for the hash for generating the nodeid