### PR TITLE
Added support for 2 cert stores

### DIFF
--- a/cfsd/main.go
+++ b/cfsd/main.go
@@ -30,14 +30,20 @@ func main() {
 	caPath := "/etc/cfsd/ca.pem"
 	dataPath := "/var/lib/cfsd"
 	var formicIP string
-	var groupIP string
-	var valueIP string
+	var grpcGroupIP string
+	var replGroupIP string
+	var grpcValueIP string
+	var replValueIP string
 	var formicCertPath string
 	var formicKeyPath string
-	var groupCertPath string
-	var groupKeyPath string
-	var valueCertPath string
-	var valueKeyPath string
+	var grpcGroupCertPath string
+	var grpcGroupKeyPath string
+	var replGroupCertPath string
+	var replGroupKeyPath string
+	var grpcValueCertPath string
+	var grpcValueKeyPath string
+	var replValueCertPath string
+	var replValueKeyPath string
 
 	baseLogger := zap.New(zap.NewJSONEncoder())
 	baseLogger.SetLevel(zap.InfoLevel)
@@ -81,12 +87,22 @@ FIND_LOCAL_NODE:
 						nodeAddr = node.Address(ADDR_GROUP_GRPC)
 						i = strings.LastIndex(nodeAddr, ":")
 						if i >= 0 {
-							groupIP = nodeAddr[:i]
+							grpcGroupIP = nodeAddr[:i]
+						}
+						nodeAddr = node.Address(ADDR_GROUP_REPL)
+						i = strings.LastIndex(nodeAddr, ":")
+						if i >= 0 {
+							replGroupIP = nodeAddr[:i]
 						}
 						nodeAddr = node.Address(ADDR_VALUE_GRPC)
 						i = strings.LastIndex(nodeAddr, ":")
 						if i >= 0 {
-							valueIP = nodeAddr[:i]
+							grpcValueIP = nodeAddr[:i]
+						}
+						nodeAddr = node.Address(ADDR_VALUE_REPL)
+						i = strings.LastIndex(nodeAddr, ":")
+						if i >= 0 {
+							replValueIP = nodeAddr[:i]
 						}
 						break FIND_LOCAL_NODE
 					}
@@ -96,10 +112,14 @@ FIND_LOCAL_NODE:
 	}
 	formicCertPath = "/etc/cfsd/" + formicIP + ".pem"
 	formicKeyPath = "/etc/cfsd/" + formicIP + "-key.pem"
-	groupCertPath = "/etc/cfsd/" + groupIP + ".pem"
-	groupKeyPath = "/etc/cfsd/" + groupIP + "-key.pem"
-	valueCertPath = "/etc/cfsd/" + valueIP + ".pem"
-	valueKeyPath = "/etc/cfsd/" + valueIP + "-key.pem"
+	grpcGroupCertPath = "/etc/cfsd/" + grpcGroupIP + ".pem"
+	grpcGroupKeyPath = "/etc/cfsd/" + grpcGroupIP + "-key.pem"
+	replGroupCertPath = "/etc/cfsd/" + replGroupIP + ".pem"
+	replGroupKeyPath = "/etc/cfsd/" + replGroupIP + "-key.pem"
+	grpcValueCertPath = "/etc/cfsd/" + grpcValueIP + ".pem"
+	grpcValueKeyPath = "/etc/cfsd/" + grpcValueIP + "-key.pem"
+	replValueCertPath = "/etc/cfsd/" + replValueIP + ".pem"
+	replValueKeyPath = "/etc/cfsd/" + replValueIP + "-key.pem"
 
 	waitGroup := &sync.WaitGroup{}
 	shutdownChan := make(chan struct{})
@@ -107,8 +127,10 @@ FIND_LOCAL_NODE:
 	groupStore, groupStoreRestartChan, err := server.NewGroupStore(&server.GroupStoreConfig{
 		GRPCAddressIndex: ADDR_GROUP_GRPC,
 		ReplAddressIndex: ADDR_GROUP_REPL,
-		CertFile:         groupCertPath,
-		KeyFile:          groupKeyPath,
+		GRPCCertFile:     grpcGroupCertPath,
+		GRPCKeyFile:      grpcGroupKeyPath,
+		ReplCertFile:     replGroupCertPath,
+		ReplKeyFile:      replGroupKeyPath,
 		CAFile:           caPath,
 		Scale:            0.4,
 		Path:             dataPath,
@@ -144,8 +166,10 @@ FIND_LOCAL_NODE:
 	valueStore, valueStoreRestartChan, err := server.NewValueStore(&server.ValueStoreConfig{
 		GRPCAddressIndex: ADDR_VALUE_GRPC,
 		ReplAddressIndex: ADDR_VALUE_REPL,
-		CertFile:         valueCertPath,
-		KeyFile:          valueKeyPath,
+		GRPCCertFile:     grpcValueCertPath,
+		GRPCKeyFile:      grpcValueKeyPath,
+		ReplCertFile:     replValueCertPath,
+		ReplKeyFile:      replValueKeyPath,
 		CAFile:           caPath,
 		Scale:            0.4,
 		Path:             dataPath,

--- a/oort/api/server/groupstore_GEN_.go
+++ b/oort/api/server/groupstore_GEN_.go
@@ -29,16 +29,20 @@ type GroupStore struct {
 	grpcServer        *grpc.Server
 	grpcAddressIndex  int
 	grpcDefaultPort   int
-	certFile          string
-	keyFile           string
+	grpcCertFile      string
+	grpcKeyFile       string
+	replCertFile      string
+	replKeyFile       string
 	caFile            string
 }
 
 type GroupStoreConfig struct {
 	GRPCAddressIndex int
 	ReplAddressIndex int
-	CertFile         string
-	KeyFile          string
+	GRPCCertFile     string
+	GRPCKeyFile      string
+	ReplCertFile     string
+	ReplKeyFile      string
 	CAFile           string
 	Path             string
 	Scale            float64
@@ -49,8 +53,10 @@ func NewGroupStore(cfg *GroupStoreConfig) (*GroupStore, chan error, error) {
 	s := &GroupStore{
 		waitGroup:        &sync.WaitGroup{},
 		grpcAddressIndex: cfg.GRPCAddressIndex,
-		certFile:         cfg.CertFile,
-		keyFile:          cfg.KeyFile,
+		grpcCertFile:     cfg.GRPCCertFile,
+		grpcKeyFile:      cfg.GRPCKeyFile,
+		replCertFile:     cfg.ReplCertFile,
+		replKeyFile:      cfg.ReplKeyFile,
 		caFile:           cfg.CAFile,
 	}
 	var err error
@@ -58,9 +64,9 @@ func NewGroupStore(cfg *GroupStoreConfig) (*GroupStore, chan error, error) {
 		AddressIndex: cfg.ReplAddressIndex,
 		UseTLS:       true,
 		MutualTLS:    true,
-		CertFile:     cfg.CertFile,
-		KeyFile:      cfg.KeyFile,
-		CAFile:       cfg.CAFile,
+		CertFile:     s.replCertFile,
+		KeyFile:      s.replKeyFile,
+		CAFile:       s.caFile,
 		DefaultPort:  12311,
 	})
 	if err != nil {
@@ -625,8 +631,8 @@ func (s *GroupStore) Startup(ctx context.Context) error {
 	tlsCfg, err := ftls.NewServerTLSConfig(&ftls.Config{
 		MutualTLS:          true,
 		InsecureSkipVerify: false,
-		CertFile:           s.certFile,
-		KeyFile:            s.keyFile,
+		CertFile:           s.grpcCertFile,
+		KeyFile:            s.grpcKeyFile,
 		CAFile:             s.caFile,
 	})
 	if err != nil {

--- a/oort/api/server/store.got
+++ b/oort/api/server/store.got
@@ -22,23 +22,27 @@ import (
 type {{.T}}Store struct {
 	sync.RWMutex
 	wait{{.T}}         *sync.WaitGroup
-	shutdownChan      chan struct{}
-	started           bool
+	shutdownChan       chan struct{}
+	started            bool
 	{{.t}}Store        store.{{.T}}Store
 	{{.t}}StoreMsgRing *ring.TCPMsgRing
-	grpcServer        *grpc.Server
-	grpcAddressIndex  int
-    grpcDefaultPort   int
-	certFile          string
-	keyFile           string
-	caFile            string
+	grpcServer         *grpc.Server
+	grpcAddressIndex   int
+    grpcDefaultPort    int
+	grpcCertFile       string
+	grpcKeyFile        string
+	replCertFile       string
+	replKeyFile        string
+	caFile             string
 }
 
 type {{.T}}StoreConfig struct {
 	GRPCAddressIndex int
 	ReplAddressIndex int
-	CertFile         string
-	KeyFile          string
+	GRPCCertFile     string
+	GRPCKeyFile      string
+	ReplCertFile     string
+	ReplKeyFile      string
 	CAFile           string
 	Path             string
 	Scale            float64
@@ -47,10 +51,12 @@ type {{.T}}StoreConfig struct {
 
 func New{{.T}}Store(cfg *{{.T}}StoreConfig) (*{{.T}}Store, chan error, error) {
 	s := &{{.T}}Store{
-		wait{{.T}}:        &sync.WaitGroup{},
+		wait{{.T}}:       &sync.WaitGroup{},
 		grpcAddressIndex: cfg.GRPCAddressIndex,
-		certFile:         cfg.CertFile,
-		keyFile:          cfg.KeyFile,
+		grpcCertFile:     cfg.GRPCCertFile,
+		grpcKeyFile:      cfg.GRPCKeyFile,
+		replCertFile:     cfg.ReplCertFile,
+		replKeyFile:      cfg.ReplKeyFile,
 		caFile:           cfg.CAFile,
 	}
 	var err error
@@ -58,9 +64,9 @@ func New{{.T}}Store(cfg *{{.T}}StoreConfig) (*{{.T}}Store, chan error, error) {
 		AddressIndex: cfg.ReplAddressIndex,
 		UseTLS:       true,
 		MutualTLS:    true,
-		CertFile:     cfg.CertFile,
-		KeyFile:      cfg.KeyFile,
-		CAFile:       cfg.CAFile,
+		CertFile:     s.replCertFile,
+		KeyFile:      s.replKeyFile,
+		CAFile:       s.caFile,
         DefaultPort:  {{if eq .t "group"}}12311{{else}}12321{{end}},
 	})
 	if err != nil {
@@ -625,8 +631,8 @@ func (s *{{.T}}Store) Startup(ctx context.Context) error {
 	tlsCfg, err := ftls.NewServerTLSConfig(&ftls.Config{
 		MutualTLS:          true,
 		InsecureSkipVerify: false,
-		CertFile:           s.certFile,
-		KeyFile:            s.keyFile,
+		CertFile:           s.grpcCertFile,
+		KeyFile:            s.grpcKeyFile,
 		CAFile:             s.caFile,
 	})
 	if err != nil {

--- a/oort/api/server/valuestore_GEN_.go
+++ b/oort/api/server/valuestore_GEN_.go
@@ -29,16 +29,20 @@ type ValueStore struct {
 	grpcServer        *grpc.Server
 	grpcAddressIndex  int
 	grpcDefaultPort   int
-	certFile          string
-	keyFile           string
+	grpcCertFile      string
+	grpcKeyFile       string
+	replCertFile      string
+	replKeyFile       string
 	caFile            string
 }
 
 type ValueStoreConfig struct {
 	GRPCAddressIndex int
 	ReplAddressIndex int
-	CertFile         string
-	KeyFile          string
+	GRPCCertFile     string
+	GRPCKeyFile      string
+	ReplCertFile     string
+	ReplKeyFile      string
 	CAFile           string
 	Path             string
 	Scale            float64
@@ -49,8 +53,10 @@ func NewValueStore(cfg *ValueStoreConfig) (*ValueStore, chan error, error) {
 	s := &ValueStore{
 		waitValue:        &sync.WaitGroup{},
 		grpcAddressIndex: cfg.GRPCAddressIndex,
-		certFile:         cfg.CertFile,
-		keyFile:          cfg.KeyFile,
+		grpcCertFile:     cfg.GRPCCertFile,
+		grpcKeyFile:      cfg.GRPCKeyFile,
+		replCertFile:     cfg.ReplCertFile,
+		replKeyFile:      cfg.ReplKeyFile,
 		caFile:           cfg.CAFile,
 	}
 	var err error
@@ -58,9 +64,9 @@ func NewValueStore(cfg *ValueStoreConfig) (*ValueStore, chan error, error) {
 		AddressIndex: cfg.ReplAddressIndex,
 		UseTLS:       true,
 		MutualTLS:    true,
-		CertFile:     cfg.CertFile,
-		KeyFile:      cfg.KeyFile,
-		CAFile:       cfg.CAFile,
+		CertFile:     s.replCertFile,
+		KeyFile:      s.replKeyFile,
+		CAFile:       s.caFile,
 		DefaultPort:  12321,
 	})
 	if err != nil {
@@ -617,8 +623,8 @@ func (s *ValueStore) Startup(ctx context.Context) error {
 	tlsCfg, err := ftls.NewServerTLSConfig(&ftls.Config{
 		MutualTLS:          true,
 		InsecureSkipVerify: false,
-		CertFile:           s.certFile,
-		KeyFile:            s.keyFile,
+		CertFile:           s.grpcCertFile,
+		KeyFile:            s.grpcKeyFile,
 		CAFile:             s.caFile,
 	})
 	if err != nil {


### PR DESCRIPTION
A different key/cert pair can be used for the GRPC port and the
replication port for oort.api.server stores.